### PR TITLE
Modify IPStack success to check the country code

### DIFF
--- a/lib/geokit/geocoders/ipstack.rb
+++ b/lib/geokit/geocoders/ipstack.rb
@@ -27,7 +27,7 @@ module Geokit
         loc.lng = result['longitude']
         loc.country_code = result['country_code']
         loc.country = result['country_name']
-        loc.success = !loc.city.nil?
+        loc.success = !loc.country_code.nil?
 
         loc
       end


### PR DESCRIPTION
Since the IP geocoding precision is not really accurate, I suggest changing the existing condition (my bad 😅) to set the success condition based on the country code resolution. In our use case, we just care about the country code and now is triggering the fallback unexpectedly when the result doesn't contain the city name.